### PR TITLE
:memo: & :bug: docs(./umirc.ts): 【目录完善】整合修改文章目录并放开了docs中的文章阅读

### DIFF
--- a/.umirc.ts
+++ b/.umirc.ts
@@ -12,31 +12,44 @@ export default defineConfig({
   menus: {
     '/main': [
       {
-        title: '概览',
-        children: ['main/guide.md'],
-      },
-      {
         title: '基本概念',
-        children: ['main/pkg-structure.md', 'main/workloop.md'],
+        children: [
+          'main/macro-structure.md',
+          'main/workloop.md',
+          'main/object-structure.md',
+        ],
       },
       {
         title: '运行核心',
         children: [
+          'main/reconciler-workflow.md',
           'main/bootstrap.md',
+          'main/priority.md',
           'main/scheduler.md',
           'main/render.md',
-          'main/commit.md',
           'main/update.md',
+          'main/fibertree-prepare.md',
+          'main/fibertree-create.md',
+          'main/fibertree-update.md',
+          'main/fibertree-commit.md',
+          'main/commit.md',
           'main/synthetic-event.md',
         ],
       },
       {
-        title: '其他',
+        title: 'Class与Hook',
         children: [
+          'main/state-effects.md',
+          'main/class-component.md',
           'main/hook.md',
-          'main/error-boundaries.md',
-          'main/context.md',
+          'main/hook-summary.md',
+          'main/hook-state.md',
+          'main/hook-effect.md',
         ],
+      },
+      {
+        title: '其他',
+        children: ['main/context.md', 'main/error-boundaries.md'],
       },
     ],
   },

--- a/docs/interview/index.md
+++ b/docs/interview/index.md
@@ -13,12 +13,12 @@ group: interview
 
 ## 现有题目
 
-1. [setState 是同步还是异步?](./01-setstate.md)
+1. [setState 是同步还是异步?](./interview/01-setstate.md)
 2. class 组件生命周期有哪些?
 3. 重复调用 setState 会发生什么?
 4. 什么是 fiber 架构?
 5. 调和算法具体干什么的?
-6. key 有什么作用,可以省略吗?
+6. [key 有什么作用,可以省略吗?](./interview/06-key.md)
 7. useState()如何实现数据持久化?
 8. useEffect()会有内存泄漏吗?
 9. `useEffect(function, deps)`中第二个参数表示依赖项, 如何实现依赖项的对比?

--- a/docs/main/hook-state.md
+++ b/docs/main/hook-state.md
@@ -163,7 +163,7 @@ dispatch({ type: 'decrement' });
 有如下代码:[![Edit hook-status](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/hook-status-vhlf8?fontsize=14&hidenavigation=1&theme=dark)
 
 ```jsx
-import { useState } from 'react';
+import React, { useState } from 'react';
 export default function App() {
   const [count, dispatch] = useState(0);
   return (

--- a/docs/main/hook-summary.md
+++ b/docs/main/hook-summary.md
@@ -333,7 +333,7 @@ export function renderWithHooks<Props, SecondArg>(
 [![Edit hook-summary](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/hook-summary-wb7zz?fontsize=14&hidenavigation=1&theme=dark)
 
 ```jsx
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 export default function App() {
   // 1. useState
   const [a, setA] = useState(1);


### PR DESCRIPTION
博主您好，我结合平时阅读这本的顺序，斗胆修改了您的当前的目录，按为文章阅读顺序进行了适当的调整
1. 没有修改文章中的任何内容，只对目录做了调整
2. `hook-summary`和`hook-state`这两份文件的修改是为了修复页面报错，具体错误原因见dumi的issue: [bug: React.createElement is undefined #725](https://github.com/umijs/dumi/issues/725)

最后感谢博主的无私贡献！