### PR TITLE
feat(CI-website): deploy to gh pages with GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  deploy:
+    name: Deployment on Node ${{ matrix.node-version }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [16]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Keep `0` for dumi last updated time feature
+      - name: Setup Node environment
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: https://registry.npmjs.org/
+      - name: Installation
+        run: |
+          npm install
+      - name: Building work
+        run: |
+          npm run build
+      - name: Deploy to Github Pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: ${{ github.event.head_commit.message }}

--- a/.umirc.ts
+++ b/.umirc.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'dumi';
-import path from 'path';
-// more config: https://d.umijs.org/config
+
+// More config: https://d.umijs.org/config.
 export default defineConfig({
   title: '图解React',
   mode: 'site',
@@ -9,6 +9,8 @@ export default defineConfig({
     '基于react@17.0.2.尽可能跟随react版本的升级,持续更新. 用大量配图的方式, 致力于将`react原理`表述清楚.',
   locales: [['zh-CN', '中文']],
   logo: '/logo.png',
+  base: '/react-illustration-series/',
+  publicPath: '/react-illustration-series/',
   menus: {
     '/main': [
       {


### PR DESCRIPTION
[Live demo](https://webprs.github.io/react-illustration-series/).

构建好的 `dist/` 文件夹以 `force_orphan` 的形式推送至 `gh-pages` 分支。