### PR TITLE
build(CI): switch to clean state installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org/
           cache: 'npm'
-      - name: Installation
+      - name: Install dependencies
         run: |
-          npm install
+          npm ci
       - name: Building work
         run: |
           npm run build


### PR DESCRIPTION
This command is similar to `npm install`,
except it's meant to be used in automated environments such as test platforms,
**continuous integration**, and deployment
-- or any situation where you want to make sure you're doing a clean install of your dependencies.

`npm ci` will be significantly faster when:

- There is a `package-lock.json` or `npm-shrinkwrap.json` file.
- The `node_modules` folder is missing or empty.

More details on official [docs](https://docs.npmjs.com/cli/v7/commands/npm-ci/).