### PR TITLE
🐛 fix: 修复legacyRenderSubtreeIntoContainer注释错误

### DIFF
--- a/docs/main/bootstrap.md
+++ b/docs/main/bootstrap.md
@@ -119,7 +119,7 @@ function legacyRenderSubtreeIntoContainer(
     });
   } else {
     // root已经初始化, 二次调用render会进入
-    // 1. 获取ReactDOMRoot对象
+    // 1. 获取FiberRoot对象
     fiberRoot = root._internalRoot;
     if (typeof callback === 'function') {
       const originalCallback = callback;


### PR DESCRIPTION
[启动过程的legacy模式的源码说明中，有一段互相冲突的地方](https://github.com/7kms/react-illustration-series/issues/43)