### PR TITLE
一个对于workLoop伪代码的阅读优化

### DIFF
--- a/docs/main/scheduler.md
+++ b/docs/main/scheduler.md
@@ -310,7 +310,8 @@ function flushWork(hasTimeRemaining, initialTime) {
 function workLoop(hasTimeRemaining, initialTime) {
   let currentTime = initialTime; // 保存当前时间, 用于判断任务是否过期
   currentTask = peek(taskQueue); // 获取队列中的第一个任务
-  while (currentTask !== null) {
+  // 当前任务不为空,同时没有中断任务
+  while (currentTask !== null && !(enableSchedulerDebugging && isSchedulerPaused)) {
     if (
       currentTask.expirationTime > currentTime &&
       (!hasTimeRemaining || shouldYieldToHost())


### PR DESCRIPTION
我再workLoop源码讲解这里遇到了一些问题，我通过阅读示例的伪代码发现。如下所示：
![image](https://user-images.githubusercontent.com/48620706/139371934-76e2d547-7444-42e4-8d95-eec95e6f765e.png)
红色部分的判断中缺少了对于暂停的判断，所以我对后面蓝色部分的代码产生了执行疑惑。通过对照源码我才发现while判读还有一部分条件。
![image](https://user-images.githubusercontent.com/48620706/139373078-f567e711-23e3-47f8-898f-a6f0b7062134.png)

所以我提出了一点小小的优化，在伪代码处将while循环的条件补齐。还有就是在此位置增加workLoop的源码链接。方便点击对照进行查看。