### PR TITLE
docs: add more details on commitBeforeMutationEffects

### DIFF
--- a/docs/main/fibertree-commit.md
+++ b/docs/main/fibertree-commit.md
@@ -223,6 +223,8 @@ function commitBeforeMutationEffects() {
 }
 ```
 
+注意：`commitBeforeMutationEffectOnFiber`实际上对应了`commitBeforeMutationLifeCycles`函数，在导入时进行了重命名
+
 1. 处理`Snapshot`标记
 
 ```js


### PR DESCRIPTION
I was confused about the relationship beteew those   two functions : `commitBeforeMutationEffectOnFiber` and `commitBeforeMutationLifeCycles` when I  read the docs .

So I hope that the docs can specity the relationship bewteen  `commitBeforeMutationEffectOnFiber` and `commitBeforeMutationLifeCycles` more clearly. 



